### PR TITLE
Import headers patch

### DIFF
--- a/syncano4-ios/SCChannelDelegate.h
+++ b/syncano4-ios/SCChannelDelegate.h
@@ -7,8 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-
-@class SCChannelNotificationMessage;
+#import "SCChannelNotificationMessage.h"
 
 @protocol SCChannelDelegate <NSObject>
 

--- a/syncano4-ios/SCCodeBox.h
+++ b/syncano4-ios/SCCodeBox.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "SCConstants.h"
+#import "SCTrace.h"
 
 @class Syncano;
 

--- a/syncano4-ios/SCWebhook.h
+++ b/syncano4-ios/SCWebhook.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "SCConstants.h"
+#import "SCWebhookResponseObject.h"
 
 @class Syncano;
 


### PR DESCRIPTION
Without those explicitly imported, Swift cannot process files properly
and doesn’t see Obj-C methods.